### PR TITLE
Setup the microcode and VM

### DIFF
--- a/src/compiler/compileExpr.ts
+++ b/src/compiler/compileExpr.ts
@@ -1,0 +1,128 @@
+import * as es from 'estree'
+
+import { BinopCommand } from './../typings/microcode'
+import { FunctionCTE, GlobalCTE } from './compileTimeEnv'
+import { CompileTimeError } from './error'
+
+export function compileExpr(node: es.Expression, fEnv: FunctionCTE, gEnv: GlobalCTE): FunctionCTE {
+  if (node.type === 'Literal') {
+    const expr = node as es.Literal
+    return compileLit(expr, fEnv, gEnv)
+  }
+
+  if (node.type === 'ConditionalExpression') {
+    const expr = node as es.ConditionalExpression
+    return compileCondExpr(expr, fEnv, gEnv)
+  }
+
+  if (node.type === 'LogicalExpression') {
+    const expr = node as es.LogicalExpression
+    return compileLogicalExpr(expr, fEnv, gEnv)
+  }
+
+  if (node.type === 'BinaryExpression') {
+    const expr = node as es.BinaryExpression
+    return compileBinaryExpr(expr, fEnv, gEnv)
+  }
+
+  if (node.type === 'FlexiAssignmentExpression') {
+    // TODO: settle left and right
+    const expr = node as es.FlexiAssignmentExpression
+    return compileExpr(expr.right, fEnv, gEnv)
+  }
+
+  if (node.type === 'CastExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'UpdateExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'SizeofExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'ValueofExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'AddressofExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'UnaryExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'MemberExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'CallExpression') {
+    throw new CompileTimeError()
+  }
+
+  if (node.type === 'SequenceExpression') {
+    throw new CompileTimeError()
+  }
+
+  throw new CompileTimeError()
+}
+
+export function compileCondExpr(
+  node: es.ConditionalExpression,
+  fEnv: FunctionCTE,
+  gCTE: GlobalCTE
+): FunctionCTE {
+  throw new CompileTimeError()
+}
+
+export function compileLogicalExpr(
+  expr: es.LogicalExpression,
+  fEnv: FunctionCTE,
+  gEnv: GlobalCTE
+): FunctionCTE {
+  const op = expr.operator
+
+  if (op !== '||' && op !== '&&') {
+    throw new CompileTimeError()
+  }
+
+  compileExpr(expr.left, fEnv, gEnv)
+  compileExpr(expr.right, fEnv, gEnv)
+  fEnv.instrs.push({
+    type: 'BinopCommand',
+    op: expr.operator as '||' | '&&' // TODO: validate
+  })
+  return fEnv
+}
+
+export function compileBinaryExpr(
+  expr: es.BinaryExpression,
+  fEnv: FunctionCTE,
+  gEnv: GlobalCTE
+): FunctionCTE {
+  const op = expr.operator as BinopCommand['op']
+
+  compileExpr(expr.left, fEnv, gEnv)
+  compileExpr(expr.right, fEnv, gEnv)
+  fEnv.instrs.push({
+    type: 'BinopCommand',
+    op // TODO: validate
+  })
+
+  return fEnv
+}
+
+export function compileLit(expr: es.Literal, fEnv: FunctionCTE, gEnv: GlobalCTE): FunctionCTE {
+  if (typeof expr.value === 'number') {
+    fEnv.instrs.push({
+      type: 'MovImmediateCommand',
+      value: expr.value,
+      encoding: '2s' // TODO
+    })
+    return fEnv
+  }
+  throw new CompileTimeError()
+}

--- a/src/compiler/compileStmt.ts
+++ b/src/compiler/compileStmt.ts
@@ -1,0 +1,68 @@
+import * as es from 'estree'
+
+import { compileExpr } from './compileExpr'
+import { FunctionCTE, GlobalCTE } from './compileTimeEnv'
+import { CompileTimeError } from './error'
+
+export function compileFunctionDefinition(
+  node: es.FunctionDeclaration,
+  fEnv: FunctionCTE,
+  gEnv: GlobalCTE
+): FunctionCTE {
+  const body = node.body
+  return compileCompoundStatement(body, fEnv, gEnv)
+}
+
+export function compileCompoundStatement(
+  node: es.BlockStatement,
+  fEnv: FunctionCTE,
+  gEnv: GlobalCTE
+): FunctionCTE {
+  for (const stmtRaw of node.body) {
+    if (stmtRaw.type === 'VariableDeclaration') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'ExpressionStatement') {
+      const stmt = stmtRaw as es.ExpressionStatement
+      compileExpr(stmt.expression, fEnv, gEnv)
+      continue
+    }
+
+    if (stmtRaw.type === 'BlockStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'IfStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'WhileStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'ForStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'ReturnStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'BreakStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'ContinueStatement') {
+      throw new CompileTimeError()
+    }
+
+    if (stmtRaw.type === 'EmptyStatement') {
+      continue
+    }
+
+    throw new CompileTimeError()
+  }
+
+  return fEnv
+}

--- a/src/compiler/compileTimeEnv.ts
+++ b/src/compiler/compileTimeEnv.ts
@@ -1,0 +1,45 @@
+import * as es from 'estree'
+
+import { DataType } from '../typings/datatype'
+import { Microcode } from '../typings/microcode'
+
+export interface VariableInfo {
+  name: string
+
+  /* The variable's datatype */
+  type: DataType
+
+  /** The "home" of a variable = rbp + offset */
+  offset: number
+
+  /** The initial value of a variable */
+  initialValue: es.Expression
+
+  /**
+   * The block where the variable is.
+   * Starts from 0, which is the args + variable declaration.
+   */
+  blkNum: number
+}
+
+export class FunctionCTE {
+  name: string
+
+  returnType?: DataType
+
+  params: Array<[string, DataType]> = []
+
+  /* A map of variables. Variable name is used as the key. */
+  variables: Record<string, VariableInfo> = {}
+
+  instrs: Array<Microcode> = []
+
+  constructor(name: string, returnType: DataType) {
+    this.name = name
+    this.returnType = returnType
+  }
+}
+
+export class GlobalCTE {
+  functions: Record<string, FunctionCTE> = {}
+}

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,0 +1,13 @@
+import { Program } from 'estree'
+
+import { Microcode } from './../typings/microcode'
+
+/**
+ * Converts the AST (from `./parser`) into
+ * a list of microcode commands (to be loaded into `./interpeter`).
+ *
+ * This is the integration point between the "compiler" and the rest of this codebase.
+ */
+export function compile(ast: Program): Array<Microcode> {
+  return []
+}

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -9,5 +9,13 @@ import { Microcode } from './../typings/microcode'
  * This is the integration point between the "compiler" and the rest of this codebase.
  */
 export function compile(ast: Program): Array<Microcode> {
-  return []
+  return [
+    {
+      type: 'CallCommand',
+      addr: 10
+    },
+    {
+      type: 'ExitCommand'
+    }
+  ]
 }

--- a/src/compiler/error.ts
+++ b/src/compiler/error.ts
@@ -1,0 +1,1 @@
+export class CompileTimeError extends Error {}

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -1,6 +1,6 @@
 // Variable determining chapter of Source is contained in this file.
 
-import { Context, Environment, Variant } from './types'
+import { Context, CustomBuiltIns, Environment, Variant } from './types'
 
 export class LazyBuiltIn {
   func: (...arg0: any) => any
@@ -90,7 +90,8 @@ export const createGlobalEnvironment = (): Environment => ({
 export const createEmptyContext = <T>(
   variant: Variant,
   externalSymbols: string[],
-  externalContext?: T
+  externalContext?: T,
+  externalBuiltIns?: CustomBuiltIns
 ): Context<T> => {
   return {
     externalSymbols,
@@ -103,7 +104,15 @@ export const createEmptyContext = <T>(
     variant,
     moduleContexts: {},
     unTypecheckedCode: [],
-    previousCode: []
+    previousCode: [],
+    externalBuiltIns,
+    cVmContext: {
+      instrs: [],
+      isRunning: false,
+      PC: 0,
+      returnValue: -1,
+      dataview: new DataView(new ArrayBuffer(0))
+    }
   }
 }
 
@@ -127,9 +136,10 @@ export const ensureGlobalEnvironmentExist = (context: Context) => {
 const createContext = <T>(
   variant: Variant = Variant.DEFAULT,
   externalSymbols: string[] = [],
-  externalContext?: T
+  externalContext?: T,
+  externalBuiltIns?: CustomBuiltIns
 ): Context => {
-  const context = createEmptyContext(variant, externalSymbols, externalContext)
+  const context = createEmptyContext(variant, externalSymbols, externalContext, externalBuiltIns)
 
   return context
 }

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,50 +1,46 @@
 /* tslint:disable:max-classes-per-file */
-import * as es from 'estree'
+import { Context, Value } from '../types'
+import { Microcode } from './../typings/microcode'
+import { RuntimeContext } from './../typings/runtime-context'
 
-import { RuntimeSourceError } from '../errors/runtimeSourceError'
-import { Context, Environment, Value } from '../types'
-import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
-import * as rttc from '../utils/rttc'
+export function* evaluate(context: Context<RuntimeContext>) {
+  // previous impl:
+  // export function* evaluate(node: es.Node, context: Context) {
+  //   const result = yield* evaluators[node.type](node, context)
+  //   yield* leave(context)
+  //   return result
+  // }
 
-class Thunk {
-  public value: Value
-  public isMemoized: boolean
-  constructor(public exp: es.Node, public env: Environment) {
-    this.isMemoized = false
-    this.value = null
+  let { externalContext: rtCtx } = context
+  let returnValue: number | undefined
+
+  while (true) {
+    // Guard clause.
+    if (!rtCtx) {
+      break
+    }
+
+    if (!rtCtx.isRunning) {
+      // TODO: should get the actual
+      // return value of main
+      returnValue = 1
+      break
+    }
+
+    const cmd: Microcode | undefined = decodePC(rtCtx, rtCtx.PC)
+    if (!cmd) {
+      break
+    }
+
+    // Execute `cmd` and amend `context` accordingly
+    yield* MACHINE[cmd.type](rtCtx)
+
+    // Update the `rtCtx` variable in this scope
+    rtCtx = context.externalContext
   }
-}
 
-function* forceIt(val: any, context: Context): Value {
-  if (val instanceof Thunk) {
-    if (val.isMemoized) return val.value
-
-    pushEnvironment(context, val.env)
-    const evalRes = yield* actualValue(val.exp, context)
-    popEnvironment(context)
-    val.value = evalRes
-    val.isMemoized = true
-    return evalRes
-  } else return val
-}
-
-export function* actualValue(exp: es.Node, context: Context): Value {
-  const evalResult = yield* evaluate(exp, context)
-  const forced = yield* forceIt(evalResult, context)
-  return forced
-}
-
-const handleRuntimeError = (context: Context, error: RuntimeSourceError): never => {
-  context.errors.push(error)
-  context.runtime.environments = context.runtime.environments.slice(
-    -context.numberOfOuterEnvironments
-  )
-  throw error
-}
-
-function* visit(context: Context, node: es.Node) {
-  context.runtime.nodes.unshift(node)
-  yield context
+  yield* leave(context)
+  return returnValue ?? undefined // undefined means some issue during execution
 }
 
 function* leave(context: Context) {
@@ -53,23 +49,19 @@ function* leave(context: Context) {
   yield context
 }
 
-const popEnvironment = (context: Context) => context.runtime.environments.shift()
-export const pushEnvironment = (context: Context, environment: Environment) => {
-  context.runtime.environments.unshift(environment)
-  context.runtime.environmentTree.insert(environment)
-}
-
-export type Evaluator<T extends es.Node> = (node: T, context: Context) => IterableIterator<Value>
-
-function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
-  let result
-  for (const statement of node.body) {
-    result = yield* evaluate(statement, context)
+function decodePC(ctx: RuntimeContext, pc: number): Microcode | undefined {
+  // TODO: Incomplete
+  return {
+    type: 'ReturnCommand'
   }
-  return result
 }
+
+/* Supporting typedef for MACHINE. */
+type EvaluatorFunction = (rtCtx: RuntimeContext) => IterableIterator<Value>
 
 /**
+ * The virtual machine used for execution
+ *
  * WARNING: Do not use object literal shorthands, e.g.
  *   {
  *     *Literal(node: es.Literal, ...) {...},
@@ -79,130 +71,211 @@ function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
  * They do not minify well, raising uncaught syntax errors in production.
  * See: https://github.com/webpack/webpack/issues/7566
  */
-// tslint:disable:object-literal-shorthand
-// prettier-ignore
-export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
-  /** Simple Values */
-  Literal: function* (node: es.Literal, _context: Context) {
-    return node.value
-  },
-
-  TemplateLiteral: function* (node: es.TemplateLiteral) {
-    // Expressions like `${1}` are not allowed, so no processing needed
-    return node.quasis[0].value.cooked
-  },
-
-  ThisExpression: function* (node: es.ThisExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  ArrayExpression: function* (node: es.ArrayExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-
-  FunctionExpression: function* (node: es.FunctionExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  ArrowFunctionExpression: function* (node: es.ArrowFunctionExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  Identifier: function* (node: es.Identifier, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  CallExpression: function* (node: es.CallExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  NewExpression: function* (node: es.NewExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  UnaryExpression: function* (node: es.UnaryExpression, context: Context) {
-    const value = yield* actualValue(node.argument, context)
-
-    const error = rttc.checkUnaryExpression(node, node.operator, value)
-    if (error) {
-      return handleRuntimeError(context, error)
-    }
-    return evaluateUnaryExpression(node.operator, value)
-  },
-
-  BinaryExpression: function* (node: es.BinaryExpression, context: Context) {
-    const left = yield* actualValue(node.left, context)
-    const right = yield* actualValue(node.right, context)
-    const error = rttc.checkBinaryExpression(node, node.operator, left, right)
-    if (error) {
-      return handleRuntimeError(context, error)
-    }
-    return evaluateBinaryExpression(node.operator, left, right)
-  },
-
-  ConditionalExpression: function* (node: es.ConditionalExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  LogicalExpression: function* (node: es.LogicalExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  VariableDeclaration: function* (node: es.VariableDeclaration, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  ContinueStatement: function* (_node: es.ContinueStatement, _context: Context) {
-    throw new Error(`not supported yet: ${_node.type}`)
-  },
-
-  BreakStatement: function* (_node: es.BreakStatement, _context: Context) {
-    throw new Error(`not supported yet: ${_node.type}`)
-  },
-
-  ForStatement: function* (node: es.ForStatement, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-
-  AssignmentExpression: function* (node: es.AssignmentExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  FunctionDeclaration: function* (node: es.FunctionDeclaration, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  IfStatement: function* (node: es.IfStatement | es.ConditionalExpression, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  ExpressionStatement: function* (node: es.ExpressionStatement, context: Context) {
-    return yield* evaluate(node.expression, context)
-  },
-
-  ReturnStatement: function* (node: es.ReturnStatement, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  WhileStatement: function* (node: es.WhileStatement, context: Context) {
-    throw new Error(`not supported yet: ${node.type}`)
-  },
-
-  BlockStatement: function* (node: es.BlockStatement, context: Context) {
+const MACHINE: { [microcode: string]: EvaluatorFunction } = {
+  ReturnCommand: function* (rtCtx) {
+    rtCtx.isRunning = false
+    rtCtx.programReturnValue = 0
     return
-  },
-
-  Program: function* (node: es.BlockStatement, context: Context) {
-    const result = yield* forceIt(yield* evaluateBlockSatement(context, node), context);
-    return result;
   }
 }
-// tslint:enable:object-literal-shorthand
 
-export function* evaluate(node: es.Node, context: Context) {
-  const result = yield* evaluators[node.type](node, context)
-  yield* leave(context)
-  return result
-}
+// import * as es from 'estree'
+
+// import { RuntimeSourceError } from '../errors/runtimeSourceError'
+// import { Context, Environment, Value } from '../types'
+// import { MemoryContext } from '../typings/memory-context'
+// import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
+// import * as rttc from '../utils/rttc'
+
+// class Thunk {
+//   public value: Value
+//   public isMemoized: boolean
+//   constructor(public exp: es.Node, public env: Environment) {
+//     this.isMemoized = false
+//     this.value = null
+//   }
+// }
+
+// function* forceIt(val: any, context: Context): Value {
+//   if (val instanceof Thunk) {
+//     if (val.isMemoized) return val.value
+
+//     pushEnvironment(context, val.env)
+//     const evalRes = yield* actualValue(val.exp, context)
+//     popEnvironment(context)
+//     val.value = evalRes
+//     val.isMemoized = true
+//     return evalRes
+//   } else return val
+// }
+
+// export function* actualValue(exp: es.Node, context: Context): Value {
+//   const evalResult = yield* evaluate(exp, context)
+//   const forced = yield* forceIt(evalResult, context)
+//   return forced
+// }
+
+// const handleRuntimeError = (context: Context, error: RuntimeSourceError): never => {
+//   context.errors.push(error)
+//   context.runtime.environments = context.runtime.environments.slice(
+//     -context.numberOfOuterEnvironments
+//   )
+//   throw error
+// }
+
+// function* visit(context: Context, node: es.Node) {
+//   context.runtime.nodes.unshift(node)
+//   yield context
+// }
+
+// function* leave(context: Context) {
+//   context.runtime.break = false
+//   context.runtime.nodes.shift()
+//   yield context
+// }
+
+// const popEnvironment = (context: Context) => context.runtime.environments.shift()
+// export const pushEnvironment = (context: Context, environment: Environment) => {
+//   context.runtime.environments.unshift(environment)
+//   context.runtime.environmentTree.insert(environment)
+// }
+
+// export type Evaluator<T extends es.Node> = (node: T, context: Context) => IterableIterator<Value>
+
+// function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
+//   let result
+//   for (const statement of node.body) {
+//     result = yield* evaluate(statement, context)
+//   }
+//   return result
+// }
+
+// /**
+//  * WARNING: Do not use object literal shorthands, e.g.
+//  *   {
+//  *     *Literal(node: es.Literal, ...) {...},
+//  *     *ThisExpression(node: es.ThisExpression, ..._ {...},
+//  *     ...
+//  *   }
+//  * They do not minify well, raising uncaught syntax errors in production.
+//  * See: https://github.com/webpack/webpack/issues/7566
+//  */
+// // tslint:disable:object-literal-shorthand
+// // prettier-ignore
+// export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
+//   /** Simple Values */
+//   Literal: function* (node: es.Literal, _context: Context) {
+//     return node.value
+//   },
+
+//   TemplateLiteral: function* (node: es.TemplateLiteral) {
+//     // Expressions like `${1}` are not allowed, so no processing needed
+//     return node.quasis[0].value.cooked
+//   },
+
+//   ThisExpression: function* (node: es.ThisExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   ArrayExpression: function* (node: es.ArrayExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   FunctionExpression: function* (node: es.FunctionExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   ArrowFunctionExpression: function* (node: es.ArrowFunctionExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   Identifier: function* (node: es.Identifier, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   CallExpression: function* (node: es.CallExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   NewExpression: function* (node: es.NewExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   UnaryExpression: function* (node: es.UnaryExpression, context: Context) {
+//     const value = yield* actualValue(node.argument, context)
+
+//     const error = rttc.checkUnaryExpression(node, node.operator, value)
+//     if (error) {
+//       return handleRuntimeError(context, error)
+//     }
+//     return evaluateUnaryExpression(node.operator, value)
+//   },
+
+//   BinaryExpression: function* (node: es.BinaryExpression, context: Context) {
+//     const left = yield* actualValue(node.left, context)
+//     const right = yield* actualValue(node.right, context)
+//     const error = rttc.checkBinaryExpression(node, node.operator, left, right)
+//     if (error) {
+//       return handleRuntimeError(context, error)
+//     }
+//     return evaluateBinaryExpression(node.operator, left, right)
+//   },
+
+//   ConditionalExpression: function* (node: es.ConditionalExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   LogicalExpression: function* (node: es.LogicalExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   VariableDeclaration: function* (node: es.VariableDeclaration, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   ContinueStatement: function* (_node: es.ContinueStatement, _context: Context) {
+//     throw new Error(`not supported yet: ${_node.type}`)
+//   },
+
+//   BreakStatement: function* (_node: es.BreakStatement, _context: Context) {
+//     throw new Error(`not supported yet: ${_node.type}`)
+//   },
+
+//   ForStatement: function* (node: es.ForStatement, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   AssignmentExpression: function* (node: es.AssignmentExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   FunctionDeclaration: function* (node: es.FunctionDeclaration, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   IfStatement: function* (node: es.IfStatement | es.ConditionalExpression, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   ExpressionStatement: function* (node: es.ExpressionStatement, context: Context) {
+//     return yield* evaluate(node.expression, context)
+//   },
+
+//   ReturnStatement: function* (node: es.ReturnStatement, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   WhileStatement: function* (node: es.WhileStatement, context: Context) {
+//     throw new Error(`not supported yet: ${node.type}`)
+//   },
+
+//   BlockStatement: function* (node: es.BlockStatement, context: Context) {
+//     return
+//   },
+
+//   Program: function* (node: es.BlockStatement, context: Context) {
+//     const result = yield* forceIt(yield* evaluateBlockSatement(context, node), context);
+//     return result;
+//   }
+// }
+// tslint:enable:object-literal-shorthand

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -33,7 +33,7 @@ export function* evaluate(context: Context<RuntimeContext>) {
     }
 
     // Execute `cmd` and amend `context` accordingly
-    yield* MACHINE[cmd.type](rtCtx)
+    yield* MACHINE[cmd.type](cmd, rtCtx)
 
     // Update the `rtCtx` variable in this scope
     rtCtx = context.externalContext
@@ -49,15 +49,25 @@ function* leave(context: Context) {
   yield context
 }
 
+let i = 0 // TODO: for testing only
+
 function decodePC(ctx: RuntimeContext, pc: number): Microcode | undefined {
   // TODO: Incomplete
+  if (i === 0) {
+    i++
+    return {
+      type: 'CallCommand',
+      instr: 10
+    }
+  }
+
   return {
     type: 'ReturnCommand'
   }
 }
 
 /* Supporting typedef for MACHINE. */
-type EvaluatorFunction = (rtCtx: RuntimeContext) => IterableIterator<Value>
+type EvaluatorFunction = (cmd: Microcode, rtCtx: RuntimeContext) => IterableIterator<Value>
 
 /**
  * The virtual machine used for execution
@@ -72,10 +82,14 @@ type EvaluatorFunction = (rtCtx: RuntimeContext) => IterableIterator<Value>
  * See: https://github.com/webpack/webpack/issues/7566
  */
 const MACHINE: { [microcode: string]: EvaluatorFunction } = {
-  ReturnCommand: function* (rtCtx) {
+  ReturnCommand: function* (cmd, rtCtx) {
     rtCtx.isRunning = false
     rtCtx.programReturnValue = 0
     return
+  },
+
+  CallCommand: function* (cmd, rtCtx) {
+    console.log('hellllllooooooo', { cmd })
   }
 }
 

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -57,12 +57,12 @@ function decodePC(ctx: RuntimeContext, pc: number): Microcode | undefined {
     i++
     return {
       type: 'CallCommand',
-      instr: 10
+      addr: 10
     }
   }
 
   return {
-    type: 'ReturnCommand'
+    type: 'ExitCommand'
   }
 }
 
@@ -82,7 +82,7 @@ type EvaluatorFunction = (cmd: Microcode, rtCtx: RuntimeContext) => IterableIter
  * See: https://github.com/webpack/webpack/issues/7566
  */
 const MACHINE: { [microcode: string]: EvaluatorFunction } = {
-  ReturnCommand: function* (cmd, rtCtx) {
+  ExitCommand: function* (cmd, rtCtx) {
     rtCtx.isRunning = false
     rtCtx.returnValue = 0
     return

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -84,7 +84,7 @@ type EvaluatorFunction = (cmd: Microcode, rtCtx: RuntimeContext) => IterableIter
 const MACHINE: { [microcode: string]: EvaluatorFunction } = {
   ReturnCommand: function* (cmd, rtCtx) {
     rtCtx.isRunning = false
-    rtCtx.programReturnValue = 0
+    rtCtx.returnValue = 0
     return
   },
 

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-classes-per-file */
 import { Context, Value } from '../types'
-import { Microcode } from './../typings/microcode'
+import { Microcode, MovImmediateCommand } from './../typings/microcode'
 
 export function* evaluate(context: Context) {
   // previous impl:
@@ -72,6 +72,20 @@ const MACHINE: { [microcode: string]: EvaluatorFunction } = {
     }
 
     ctx.cVmContext.PC++
+  },
+
+  MovImmediateCommand: function* (cmd, ctx) {
+    const immCmd = cmd as MovImmediateCommand
+    debugPrint(immCmd.type + ' ' + immCmd.value + ' ' + immCmd.encoding, ctx)
+    ctx.cVmContext.PC++
+  }
+}
+
+function debugPrint(str: string, ctx: Context): void {
+  if (ctx.externalBuiltIns?.rawDisplay) {
+    ctx.externalBuiltIns.rawDisplay(undefined, str, ctx)
+  } else {
+    console.log(str)
   }
 }
 

--- a/src/interpreter/runtimeContext.ts
+++ b/src/interpreter/runtimeContext.ts
@@ -1,8 +1,0 @@
-import { RuntimeContext } from '../typings/runtime-context'
-
-export const DEFAULT_RUNTIME_CTX: RuntimeContext = {
-  isRunning: true,
-  PC: 0,
-  returnValue: -1,
-  dataview: new DataView(new ArrayBuffer(2 ** 9))
-}

--- a/src/interpreter/runtimeContext.ts
+++ b/src/interpreter/runtimeContext.ts
@@ -1,0 +1,8 @@
+import { RuntimeContext } from '../typings/runtime-context'
+
+export const DEFAULT_RUNTIME_CTX: RuntimeContext = {
+  isRunning: true,
+  PC: 0,
+  returnValue: -1,
+  dataview: new DataView(new ArrayBuffer(2 ** 9))
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,10 +13,11 @@ function convertStatement(translationUnit: TranslationUnitContext): es.Statement
 }
 
 function convertSource(translationUnit: TranslationUnitContext): es.Program {
+  const blockStmt = convertStatement(translationUnit) as es.BlockStatement
   return {
     type: 'Program',
     sourceType: 'script',
-    body: [convertStatement(translationUnit)]
+    body: blockStmt.body
   }
 }
 

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -4,6 +4,7 @@ import { IOptions, Result } from '..'
 import { compile } from '../compiler/compiler'
 import { CannotFindModuleError } from '../errors/localImportErrors'
 import { evaluate } from '../interpreter/interpreter'
+import { DEFAULT_RUNTIME_CTX } from '../interpreter/runtimeContext'
 import { hoistAndMergeImports } from '../localImports/transformers/hoistAndMergeImports'
 import { removeExports } from '../localImports/transformers/removeExports'
 import { removeNonSourceModuleImports } from '../localImports/transformers/removeNonSourceModuleImports'
@@ -30,15 +31,7 @@ const DEFAULT_SOURCE_OPTIONS: IOptions = {
 /* Setup the memory context, dataview (binary values), etc. */
 function setupContext(program: Array<Microcode>, context: Context): Context<RuntimeContext> {
   // TODO: Setup the memory context
-
-  const runtimeContext: RuntimeContext = {
-    isRunning: true,
-    PC: 0,
-    programReturnValue: -1,
-    dataview: new DataView(new ArrayBuffer(10))
-  }
-
-  context.externalContext = runtimeContext
+  context.externalContext = { ...DEFAULT_RUNTIME_CTX }
 
   return context
 }

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -1,6 +1,7 @@
 import * as es from 'estree'
 
 import { IOptions, Result } from '..'
+import { compile } from '../compiler/compiler'
 import { CannotFindModuleError } from '../errors/localImportErrors'
 import { evaluate } from '../interpreter/interpreter'
 import { hoistAndMergeImports } from '../localImports/transformers/hoistAndMergeImports'
@@ -9,7 +10,9 @@ import { removeNonSourceModuleImports } from '../localImports/transformers/remov
 import { parse } from '../parser/parser'
 import { PreemptiveScheduler } from '../schedulers'
 import { Context, Scheduler, Variant } from '../types'
+import { RuntimeContext } from '../typings/runtime-context'
 import { validateAndAnnotate } from '../validator/validator'
+import { Microcode } from './../typings/microcode'
 import { determineVariant, resolvedErrorPromise } from './utils'
 
 const DEFAULT_SOURCE_OPTIONS: IOptions = {
@@ -24,8 +27,38 @@ const DEFAULT_SOURCE_OPTIONS: IOptions = {
   throwInfiniteLoops: true
 }
 
-function runInterpreter(program: es.Program, context: Context, options: IOptions): Promise<Result> {
-  const it = evaluate(program, context)
+/* Setup the memory context, dataview (binary values), etc. */
+function setupContext(program: Array<Microcode>, context: Context): Context<RuntimeContext> {
+  // TODO: Setup the memory context
+
+  const runtimeContext: RuntimeContext = {
+    isRunning: true,
+    PC: 0,
+    programReturnValue: -1,
+    dataview: new DataView(new ArrayBuffer(10))
+  }
+
+  context.externalContext = runtimeContext
+
+  return context
+}
+
+function runInterpreter(
+  program: Array<Microcode>,
+  context: Context,
+  options: IOptions
+): Promise<Result> {
+  // previous:
+  // function runInterpreter(program: es.Program, context: Context, options: IOptions): Promise<Result> {
+  //   const it = evaluate(program, context)
+  //   const scheduler: Scheduler = new PreemptiveScheduler(options.steps)
+  //   return scheduler.run(it, context)
+  // }
+
+  const runtimeCtx: Context<RuntimeContext> = setupContext(program, context)
+
+  const it = evaluate(runtimeCtx)
+
   const scheduler: Scheduler = new PreemptiveScheduler(options.steps)
   return scheduler.run(it, context)
 }
@@ -67,7 +100,9 @@ export async function sourceRunner(
     return sourceRunner(code, context, options)
   }
 
-  return runInterpreter(program, context, theOptions)
+  const microcode = compile(program)
+
+  return runInterpreter(microcode, context, theOptions)
 }
 
 export async function sourceFilesRunner(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 /*
-	This file contains definitions of some interfaces and classes that are used in Source (such as
-	error-related classes).
+  This file contains definitions of some interfaces and classes that are used in Source (such as
+  error-related classes).
 */
 
 /* tslint:disable:max-classes-per-file */
@@ -9,6 +9,7 @@ import { SourceLocation } from 'acorn'
 import * as es from 'estree'
 
 import { EnvTree } from './createContext'
+import { CVMContext } from './typings/runtime-context'
 
 /**
  * Defines functions that act as built-ins, but might rely on
@@ -141,6 +142,18 @@ export interface Context<T = any> {
    * Code previously executed in this context
    */
   previousCode: string[]
+
+  /**
+   * External builtins.
+   * If defined, the user should call the appropriate method instead.
+   * E.g. display in web application
+   */
+  externalBuiltIns?: CustomBuiltIns
+
+  /**
+   * SourC's context
+   */
+  cVmContext: CVMContext
 }
 
 export type ModuleContext = {
@@ -217,8 +230,8 @@ export interface Scheduler {
 }
 
 /*
-	Although the ESTree specifications supposedly provide a Directive interface, the index file does not seem to export it.
-	As such this interface was created here to fulfil the same purpose.
+  Although the ESTree specifications supposedly provide a Directive interface, the index file does not seem to export it.
+  As such this interface was created here to fulfil the same purpose.
  */
 export interface Directive extends es.ExpressionStatement {
   type: 'ExpressionStatement'

--- a/src/typings/microcode.ts
+++ b/src/typings/microcode.ts
@@ -1,0 +1,52 @@
+/**
+ * Collection of recognised microcode.
+ *
+ * This is the API between the compiler and interpreter.
+ */
+export interface MicrocodeMap {
+  MovCommand: MovCommand
+  LoadCommand: LoadCommand
+  BinopCommand: BinopCommand
+  CallCommand: CallCommand
+  ReturnCommand: ReturnCommand
+  PushCommand: PushCommand
+}
+
+/* Union types in MicrocodeMap */
+export type Microcode = MicrocodeMap[keyof MicrocodeMap]
+
+/* Base of all commands */
+export interface BaseCommand {
+  type: string
+}
+
+export interface MovCommand extends BaseCommand {
+  type: 'MovCommand'
+  numBytes: number
+  from: any // ?
+  to: string
+}
+
+export interface LoadCommand extends BaseCommand {
+  type: 'LoadCommand'
+  value: number
+}
+
+export interface BinopCommand extends BaseCommand {
+  type: 'BinopCommand'
+  op: '+' | '-' | '*' | '/' | '%'
+}
+
+export interface CallCommand extends BaseCommand {
+  type: 'CallCommand'
+  instr: number
+}
+
+export interface ReturnCommand extends BaseCommand {
+  type: 'ReturnCommand'
+}
+
+export interface PushCommand extends BaseCommand {
+  type: 'PushCommand'
+  from: any
+}

--- a/src/typings/microcode.ts
+++ b/src/typings/microcode.ts
@@ -63,7 +63,7 @@ export interface OffsetRspCommand extends BaseCommand {
  */
 export interface BinopCommand extends BaseCommand {
   type: 'BinopCommand'
-  op: '+' | '-' | '*' | '/' | '%' | '>' | '>=' | '<' | '<='
+  op: '+' | '-' | '*' | '/' | '%' | '>' | '>=' | '<' | '<=' | '==' | '!=' | '||' | '&&'
 }
 
 /**

--- a/src/typings/microcode.ts
+++ b/src/typings/microcode.ts
@@ -4,12 +4,14 @@
  * This is the API between the compiler and interpreter.
  */
 export interface MicrocodeMap {
+  MovImmediateCommand: MovImmediateCommand
   MovCommand: MovCommand
-  LoadCommand: LoadCommand
+  OffsetRspCommand: OffsetRspCommand
   BinopCommand: BinopCommand
+  UnopCommand: UnopCommand
   CallCommand: CallCommand
   ReturnCommand: ReturnCommand
-  PushCommand: PushCommand
+  ExitCommand: ExitCommand
 }
 
 /* Union types in MicrocodeMap */
@@ -20,33 +22,91 @@ export interface BaseCommand {
   type: string
 }
 
-export interface MovCommand extends BaseCommand {
-  type: 'MovCommand'
-  numBytes: number
-  from: any // ?
-  to: string
+/**
+ * Moves an immediate value onto RSP.
+ */
+export interface MovImmediateCommand {
+  type: 'MovImmediateCommand'
+  value: number
+
+  /**
+   * This field indicates how to store the `value in binary.
+   *
+   * 'ieee': refers to using IEEE format
+   * '2s': refers to using the 2s complement
+   */
+  encoding: 'ieee' | '2s'
 }
 
-export interface LoadCommand extends BaseCommand {
-  type: 'LoadCommand'
+/**
+ * Moves a value from the one memory location to
+ * another memory location.
+ */
+export interface MovCommand extends BaseCommand {
+  type: 'MovCommand'
+  from: MovAddressingMode
+  to: MovAddressingMode
+}
+
+/**
+ * Sets the rsp by:
+ *
+ * `rsp = rsp + value`
+ */
+export interface OffsetRspCommand extends BaseCommand {
+  type: 'OffsetRSP'
   value: number
 }
 
+/**
+ * Encapusulates the various binary operators.
+ */
 export interface BinopCommand extends BaseCommand {
   type: 'BinopCommand'
-  op: '+' | '-' | '*' | '/' | '%'
+  op: '+' | '-' | '*' | '/' | '%' | '>' | '>=' | '<' | '<='
 }
 
+/**
+ * Encapsulates the unary operators.
+ *
+ * Note: `*` here refers to the dereference operator.
+ */
+export interface UnopCommand extends BaseCommand {
+  type: 'UnopCommand'
+  op: '*' | '!' | 'sizeof' | '++' | '--' | '-'
+}
+
+/**
+ * A helper interface to define the possible addressing modes.
+ *
+ * See also the type guard `isAbsAddressingMode()`
+ */
+export type MovAddressingMode =
+  | {
+      type: 'absolute'
+      address: number
+    }
+  | {
+      type: 'relative'
+      reg: 'rsp' | 'rbp'
+      offset: number
+    }
+
+/**
+ * Calls some function f, where f is located at `addr`.
+ */
 export interface CallCommand extends BaseCommand {
   type: 'CallCommand'
-  instr: number
+  addr: number
 }
 
+/**
+ * Returns from some function call to previous one.
+ */
 export interface ReturnCommand extends BaseCommand {
   type: 'ReturnCommand'
 }
 
-export interface PushCommand extends BaseCommand {
-  type: 'PushCommand'
-  from: any
+export interface ExitCommand extends BaseCommand {
+  type: 'ExitCommand'
 }

--- a/src/typings/runtime-context.ts
+++ b/src/typings/runtime-context.ts
@@ -1,12 +1,9 @@
+import { Microcode } from './microcode'
 /**
- * Represents the runtime context, which is passed
+ * Represents the VM needed for C to run, which is passed
  * around during evaluation.
- *
- * This is embedded into Context.
- *
- * See also: `Context.externalContext`
  */
-export interface RuntimeContext {
+export interface CVMContext {
   /* Determines if the virtual machine is still running. */
   isRunning: boolean
 
@@ -22,6 +19,12 @@ export interface RuntimeContext {
 
   /** The returned value of `main` */
   returnValue: number
+
+  /**
+   * List of instructions.
+   * TODO: Should go into dataview?
+   */
+  instrs: Microcode[]
 
   dataview: DataView
 }

--- a/src/typings/runtime-context.ts
+++ b/src/typings/runtime-context.ts
@@ -1,0 +1,27 @@
+/**
+ * Represents the runtime context, which is passed
+ * around during evaluation.
+ *
+ * This is embedded into Context.
+ *
+ * See also: `Context.externalContext`
+ */
+export interface RuntimeContext {
+  /* Determines if the virtual machine is still running. */
+  isRunning: boolean
+
+  /**
+   * Program counter. This number should be an address/index
+   * into the dataview. The value at dataview should point to
+   * some valid instruction location.
+   *
+   * In other words:
+   * dataview[PC] = <some instruction node>
+   */
+  PC: number
+
+  /** The returned value of `main` */
+  programReturnValue: number
+
+  dataview: DataView
+}

--- a/src/typings/runtime-context.ts
+++ b/src/typings/runtime-context.ts
@@ -21,7 +21,7 @@ export interface RuntimeContext {
   PC: number
 
   /** The returned value of `main` */
-  programReturnValue: number
+  returnValue: number
 
   dataview: DataView
 }


### PR DESCRIPTION
Attempt to setup the microcode and VM into the existing codebase. I have no clue if it will work for more complex microcode commands.

The codebase uses a lot of JS generator functions (similar to streams in Java), which is very confusing.

Much of this is still a draft. Todos:
- [x]  Decide on the actual set of microcode
- [x] Decide on the interface for `RuntimeContext`, the context object being passed around during runtime
