### PR TITLE
Update compile time environment

### DIFF
--- a/src/compiler/compileFunctionDef.ts
+++ b/src/compiler/compileFunctionDef.ts
@@ -1,0 +1,138 @@
+import * as es from 'estree'
+
+import { compileBlockStatement } from './compileStmt'
+import { BlockNode, FunctionCTE, GlobalCTE, VariableInfo } from './compileTimeEnv'
+import { CompileTimeError } from './error'
+
+export function compileFunctionDefinition(node: es.FunctionDeclaration, gEnv: GlobalCTE): void {
+  const { name, datatype } = node.id!
+  const { params } = node
+  const paramsLs = getParamsVarInfo(params)
+
+  const blkBody = node.body
+  const { block, offset } = scanBlkVariables(blkBody.body)
+
+  const fEnv = new FunctionCTE(name, datatype, paramsLs, block)
+
+  fEnv.instrs.push({
+    type: 'OffsetRSP',
+    value: offset
+  })
+
+  compileBlockStatement(blkBody, fEnv, gEnv)
+  gEnv.functions[fEnv.name] = fEnv
+  console.log({ gEnv })
+}
+
+function getParamsVarInfo(ls: es.Pattern[]): VariableInfo[] {
+  const rv: VariableInfo[] = []
+  for (const ele of ls) {
+    if (ele.type !== 'Identifier') {
+      continue
+    }
+    rv.push({
+      name: ele.name,
+      type: ele.datatype,
+      offset: -1 // placeholder value
+    })
+  }
+  return rv
+}
+
+/**
+ * Scans for a list of variables in a given block.
+ *
+ * 2 passes are used to 'hoist' the variable declarations up. This is to
+ * simplify the debugging/tracing process.
+ *
+ * It also check for uniqueness within block depths.
+ */
+function scanBlkVariables(
+  stmts: es.Statement[],
+  initOffset: number = 0
+): { block: BlockNode; offset: number } {
+  let nextOffset = initOffset
+
+  const newBlock = new BlockNode()
+
+  for (const stmtRaw of stmts) {
+    if (stmtRaw.type === 'VariableDeclaration') {
+      const stmt = stmtRaw as es.VariableDeclaration
+
+      for (const declaration of stmt.declarations) {
+        if (declaration.id.type !== 'Identifier') continue
+
+        const ident = declaration.id as es.Identifier
+        const variable: VariableInfo = {
+          name: ident.name,
+          type: ident.datatype,
+          offset: nextOffset
+        }
+        newBlock.addVariable(variable)
+        nextOffset += 8 // TODO: Account for structs and arrays.
+      }
+    }
+  }
+  throwOnDuplicateVars(Object.values(newBlock.block))
+
+  for (const stmtRaw of stmts) {
+    if (stmtRaw.type === 'WhileStatement') {
+      const stmt = stmtRaw as es.WhileStatement
+      const { block, offset } = scanBlkVariables([stmt.body], nextOffset)
+      nextOffset = offset
+      newBlock.addChild(block)
+      continue
+    }
+
+    if (stmtRaw.type === 'IfStatement') {
+      const stmt = stmtRaw as es.IfStatement
+      const { block: consBlockNode, offset: consOffset } = scanBlkVariables(
+        [stmt.consequent],
+        nextOffset
+      )
+      nextOffset = consOffset
+      newBlock.addChild(consBlockNode)
+
+      if (stmt.alternate) {
+        const { block: altBlockNode, offset: altOffset } = scanBlkVariables(
+          [stmt.alternate],
+          nextOffset
+        )
+        nextOffset = altOffset
+        newBlock.addChild(altBlockNode)
+      }
+
+      continue
+    }
+
+    if (stmtRaw.type === 'ForStatement') {
+      const stmt = stmtRaw as es.ForStatement
+      const { block, offset } = scanBlkVariables([stmt.body], nextOffset)
+      nextOffset = offset
+      newBlock.addChild(block)
+      continue
+    }
+
+    if (stmtRaw.type === 'BlockStatement') {
+      const stmt = stmtRaw as es.BlockStatement
+      const { block, offset } = scanBlkVariables(stmt.body, nextOffset)
+      nextOffset = offset
+      newBlock.addChild(block)
+      continue
+    }
+  }
+
+  return { block: newBlock, offset: nextOffset }
+}
+
+function throwOnDuplicateVars(ls: VariableInfo[]): void {
+  const symbols: { [name: string]: boolean } = {}
+
+  ls.forEach(ele => {
+    if (symbols[ele.name]) {
+      throw new CompileTimeError()
+    }
+
+    symbols[ele.name] = true
+  })
+}

--- a/src/compiler/compileTimeEnv.ts
+++ b/src/compiler/compileTimeEnv.ts
@@ -1,8 +1,60 @@
 import * as es from 'estree'
 
 import { DataType } from '../typings/datatype'
-import { Microcode } from '../typings/microcode'
+import { Microcode } from './../typings/microcode'
+import { CompileTimeError } from './error'
 
+/** A Block maps a variable name to its information. */
+export type Block = Record<string, VariableInfo>
+
+/**
+ * A BlockNode is a tree structure that
+ * helps to track the block nesting levels. */
+export class BlockNode {
+  /** The actual block at this node. */
+  block: Block = {}
+
+  /** A list of its children. */
+  children: BlockNode[] = []
+
+  /** A block's parent. */
+  parent?: BlockNode | undefined
+
+  /**
+   * Gets a variable using its symbol.
+   *
+   * Looks at the current node, then traverse
+   * upwards if parent exists.
+   */
+  getVariable(symbol: string): VariableInfo {
+    if (this.block[symbol]) {
+      return this.block[symbol]
+    }
+
+    if (!this.parent) {
+      throw new CompileTimeError()
+    }
+
+    return this.parent.getVariable(symbol)
+  }
+
+  addVariable(variable: VariableInfo): void {
+    if (this.block[variable.name]) {
+      throw new CompileTimeError()
+    }
+
+    this.block[variable.name] = variable
+  }
+
+  addChild(child: BlockNode): void {
+    this.children.push(child)
+    child.parent = this
+  }
+}
+
+/**
+ * Represents a variable's information.
+ */
 export interface VariableInfo {
   name: string
 
@@ -13,30 +65,92 @@ export interface VariableInfo {
   offset: number
 
   /** The initial value of a variable */
-  initialValue: es.Expression
-
-  /**
-   * The block where the variable is.
-   * Starts from 0, which is the args + variable declaration.
-   */
-  blkNum: number
+  initialValue?: es.Expression
 }
 
 export class FunctionCTE {
   name: string
 
-  returnType?: DataType
+  returnType: DataType
 
-  params: Array<[string, DataType]> = []
+  params: VariableInfo[] = []
 
-  /* A map of variables. Variable name is used as the key. */
-  variables: Record<string, VariableInfo> = {}
+  instrs: Microcode[] = []
 
-  instrs: Array<Microcode> = []
+  /**
+   * Overall tree of BlockNodes.
+   *
+   * This tree is built at the start of the
+   * compilation process of FunctionDeclaration.
+   *
+   * During the compilation of each statement,
+   * `currBlockNode` is used to traverse up and down.
+   */
+  variables: BlockNode
 
-  constructor(name: string, returnType: DataType) {
+  /**
+   * A counter to track the next offset.
+   */
+  nextOffset: number = 0
+
+  /**
+   * Current BlockNode while compiling each stmt/block.
+   */
+  currBlockNode?: BlockNode | undefined
+
+  constructor(name: string, returnType: DataType, params: VariableInfo[], blockNode: BlockNode) {
     this.name = name
     this.returnType = returnType
+
+    const firstBlk = new BlockNode()
+
+    // Initialise the first block with function arguments and topLevelVars.
+    for (let i = 0; i < params.length; i++) {
+      const param = params[i]
+      const paramInfo = {
+        ...param,
+        offset: i * -8,
+        initialValue: undefined,
+        depth: 0
+      }
+      firstBlk.block[param.name] = paramInfo
+    }
+
+    const topLevelVars = Object.values(blockNode.block)
+    for (const v of topLevelVars) {
+      if (firstBlk.block[v.name]) {
+        throw new CompileTimeError()
+      }
+
+      firstBlk.block[v.name] = v
+    }
+
+    firstBlk.children = blockNode.children
+    this.variables = firstBlk
+    this.currBlockNode = firstBlk
+  }
+
+  /** Performs a lookup for a variable based on its block. */
+  getVariable(name: string): VariableInfo {
+    if (!this.currBlockNode) {
+      throw new CompileTimeError()
+    }
+
+    return this.currBlockNode.getVariable(name)
+  }
+
+  /* For entering a block. */
+  enterBlock(blockNum: number): void {
+    if (!this.currBlockNode) {
+      throw new CompileTimeError()
+    }
+
+    this.currBlockNode = this.currBlockNode.children[blockNum]
+  }
+
+  /* For exiting a block. */
+  exitBlock(): void {
+    this.currBlockNode = this.currBlockNode?.parent
   }
 }
 

--- a/src/compiler/compileVariableDef.ts
+++ b/src/compiler/compileVariableDef.ts
@@ -1,0 +1,48 @@
+import * as es from 'estree'
+
+import { compileExpr } from './compileExpr'
+import { FunctionCTE, GlobalCTE } from './compileTimeEnv'
+import { CompileTimeError } from './error'
+
+/* Compile and load in a variable definition's initial expression. */
+export function compileVariableDeclaration(
+  node: es.VariableDeclaration,
+  fEnv: FunctionCTE,
+  gEnv: GlobalCTE
+): FunctionCTE {
+  for (const declaration of node.declarations) {
+    if (declaration.id.type !== 'Identifier') {
+      throw new CompileTimeError()
+    }
+
+    const ident = declaration.id as es.Identifier
+    const varInfo = fEnv.getVariable(ident.name)
+
+    if (!declaration.init) {
+      continue
+    }
+
+    compileExpr(declaration.init, fEnv, gEnv)
+    fEnv.instrs.push(
+      {
+        type: 'MovCommand',
+        from: {
+          type: 'relative',
+          reg: 'rsp',
+          offset: -8
+        },
+        to: {
+          type: 'relative',
+          reg: 'rbp',
+          offset: varInfo.offset
+        }
+      },
+      {
+        type: 'OffsetRSP',
+        value: -8
+      }
+    )
+  }
+
+  return fEnv
+}

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,8 +1,8 @@
 import * as es from 'estree'
 
 import { Microcode } from './../typings/microcode'
-import { compileFunctionDefinition } from './compileStmt'
-import { FunctionCTE, GlobalCTE } from './compileTimeEnv'
+import { compileFunctionDefinition } from './compileFunctionDef'
+import { GlobalCTE } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 
 /**
@@ -11,19 +11,13 @@ import { CompileTimeError } from './error'
  *
  * This is the integration point between the "compiler" and the rest of this codebase.
  */
-export function compile(ast: es.Program): Array<Microcode> {
+export function compile(ast: es.Program): Microcode[] {
   const stmts = ast.body as es.Statement[]
   const gEnv = new GlobalCTE()
 
   for (const stmtRaw of stmts) {
     if (stmtRaw.type === 'FunctionDeclaration') {
-      const stmt = stmtRaw as es.FunctionDeclaration
-
-      const { name, datatype } = stmt.id!
-      const fEnv = new FunctionCTE(name, datatype)
-
-      compileFunctionDefinition(stmtRaw as es.FunctionDeclaration, fEnv, gEnv)
-      gEnv.functions[fEnv.name] = fEnv
+      compileFunctionDefinition(stmtRaw, gEnv)
       continue
     }
 

--- a/src/compiler/utils.ts
+++ b/src/compiler/utils.ts
@@ -1,0 +1,9 @@
+import { DataType } from '../typings/datatype'
+import { BlockNode, FunctionCTE, GlobalCTE } from './compileTimeEnv'
+
+export function makeEmptyGlobalContext(): GlobalCTE {
+  const gEnv = new GlobalCTE()
+  const fEnv = new FunctionCTE('main', DataType.INT, [], new BlockNode())
+
+  return gEnv
+}

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-classes-per-file */
 import { Context, Value } from '../types'
-import { Microcode, MovImmediateCommand } from './../typings/microcode'
+import { BinopCommand, Microcode, MovImmediateCommand } from './../typings/microcode'
 
 export function* evaluate(context: Context) {
   // previous impl:
@@ -77,6 +77,11 @@ const MACHINE: { [microcode: string]: EvaluatorFunction } = {
   MovImmediateCommand: function* (cmd, ctx) {
     const immCmd = cmd as MovImmediateCommand
     debugPrint(immCmd.type + ' ' + immCmd.value + ' ' + immCmd.encoding, ctx)
+    ctx.cVmContext.PC++
+  },
+
+  BinopCommand: function* (cmd, ctx) {
+    const binop = cmd as BinopCommand
     ctx.cVmContext.PC++
   }
 }

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -94,6 +94,7 @@ export async function sourceRunner(
 
   const microcode = compile(program)
   updateContext(microcode, context)
+  console.log({ microcode })
 
   return runInterpreter(microcode, context, theOptions)
 }


### PR DESCRIPTION
There was an issue with the frames (or list approach) to the block frames. Since we declared the "home" of each variable early on, we need to be able to locate them back when we are compiling in the same block.

So, the identifier+depth is not enough to identify them (you can have 2 variables called x at some depth 2 in the same program).

This PR mainly changes the frames approach. Instead of a list, we have a tree like structure, that is tracking which block we are currently compiling.